### PR TITLE
Ensure user is in GOPATH when installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Exalysis will do its format, lint, and test checks on any solution, but specific
 
 ## Installation
 
+Ensure you are in a project in your `$GOPATH` when executing these commands.
+
 ```
 GO111MODULE=on go get github.com/exercism/exalysis
 GO111MODULE=on go install github.com/exercism/exalysis/cmd/exalysis


### PR DESCRIPTION
Add instruction for user to be in GOPATH when installing exalysis. If they are not in their GOPATH the following error occurs:
```
GO111MODULE=on go install github.com/exercism/exalysis/cmd/exalysis
can't load package: cannot find module providing package github.com/exercism/exalysis/cmd/exalysis: working directory is not part of a module
```