### PR TITLE
remove commented 'replace' directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,3 @@ require (
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/tools v0.0.0-20200925191224-5d1fdd8fa346 // indirect
 )
-
-//replace golang.org/x/lint => github.com/golang/lint v0.0.0-20180702182130-06c8688daad7
-
-// replace github.com/exercism/go-analyzer => ../go-analyzer
-
-// replace github.com/tehsphinx/astrav => ../astrav


### PR DESCRIPTION
this relates 
- https://github.com/golang/go/issues/44840
- TODO:README update MR

when trying (go > 1.18)
```sh
go install -x github.com/exercism/exalysis/cmd/exalysis@latest
```
getting 
```
go: downloading github.com/exercism/exalysis v0.4.7
go: github.com/exercism/exalysis@latest (in github.com/exercism/exalysis@v0.4.7):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```